### PR TITLE
Allow specifying custom nested headers

### DIFF
--- a/cypress/e2e/signatures.cy.js
+++ b/cypress/e2e/signatures.cy.js
@@ -20,9 +20,9 @@ describe('signature tests', () => {
 
     cy.get('#sign').within(() => {
       cy.get('[aria-controls="payloadTextSection"]').should('be.visible').click()
-      cy.get('#payload', { timeout: 1000 }).type('foobar')
+      cy.get('#payload', { timeout: 1000 }).type('hello world')
       cy.get('input[name="headerkey"]').first().type('3')
-      cy.get('input[name="headerval"]').first().type('text/plain')
+      cy.get('input[name="headerval"]').first().type('application/json')
       cy.get('.btn-primary').should('be.visible').click()
     })
 
@@ -31,6 +31,7 @@ describe('signature tests', () => {
       .then(() => {
         cy.wrap(sigBody.byteLength).should('be.greaterThan',0)
         cy.wrap(sigHex).should('be.a', 'string').should('not.be.empty')
+        cy.log('signature hex:', sigHex)
       })
     
   })

--- a/cypress/e2e/signatures.cy.js
+++ b/cypress/e2e/signatures.cy.js
@@ -21,7 +21,8 @@ describe('signature tests', () => {
     cy.get('#sign').within(() => {
       cy.get('[aria-controls="payloadTextSection"]').should('be.visible').click()
       cy.get('#payload', { timeout: 1000 }).type('foobar')
-      cy.get('#contenttype').type('text/plain')
+      cy.get('input[name="headerkey"]').first().type('3')
+      cy.get('input[name="headerval"]').first().type('text/plain')
       cy.get('.btn-primary').should('be.visible').click()
     })
 

--- a/internal/signer/sig.go
+++ b/internal/signer/sig.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +21,9 @@ const ISSUER_HEADER_KEY = int64(391)
 const ISSUER_HEADER_FEED = int64(392)
 const ISSUER_HEADER_REG_INFO = int64(393)
 
-func PrintHeaders(headers map[interface{}]interface{}) string {
+const DEFAULT_CONTENT_TYPE = "text/plain"
+
+func PrintHeaders(headers map[any]any) string {
 	returnValue := []string{}
 	for key, value := range headers {
 		var parsedVal string
@@ -30,7 +33,7 @@ func PrintHeaders(headers map[interface{}]interface{}) string {
 			} else {
 				parsedVal = base64.StdEncoding.EncodeToString(v)
 			}
-		} else if v, ok := value.(map[interface{}]interface{}); ok {
+		} else if v, ok := value.(map[any]any); ok {
 			parsedVal = fmt.Sprintf("[ %v ]", PrintHeaders(v))
 		} else {
 			parsedVal = fmt.Sprintf("%v", value)
@@ -41,15 +44,15 @@ func PrintHeaders(headers map[interface{}]interface{}) string {
 	return strings.Join(returnValue, ", ")
 }
 
-func DefaultHeaders(contentType string, hostport string) cose.ProtectedHeader {
+func DefaultHeaders(hostport string) cose.ProtectedHeader {
 	hostport = strings.ReplaceAll(hostport, ":", "%3A")
 	return cose.ProtectedHeader{
 		cose.HeaderLabelAlgorithm:   cose.AlgorithmES256,
-		cose.HeaderLabelContentType: contentType,
+		cose.HeaderLabelContentType: DEFAULT_CONTENT_TYPE,
 		cose.HeaderLabelKeyID:       []byte("#" + keys.GetPublicKeyIdDefault()),
 		ISSUER_HEADER_KEY:           "did:web:" + hostport,
 		ISSUER_HEADER_FEED:          "demo",
-		ISSUER_HEADER_REG_INFO: map[interface{}]interface{}{
+		ISSUER_HEADER_REG_INFO: map[any]any{
 			"register_by": uint64(time.Now().Add(24 * time.Hour).Unix()),
 			"sequence_no": uint64(1),
 			"issuance_ts": uint64(time.Now().Unix()),
@@ -57,15 +60,139 @@ func DefaultHeaders(contentType string, hostport string) cose.ProtectedHeader {
 	}
 }
 
-func CreateSignature(payload []byte, contentType string, hostport string) ([]byte, error) {
+func headerKeyFromString(key string) any {
+	var detectedKey any
+	if intKey, err := strconv.ParseInt(key, 10, 64); err == nil {
+		detectedKey = intKey
+	} else {
+		detectedKey = key
+	}
+	return detectedKey
+}
+
+func setValInAny(src *any, key any, value any, ignoreIfExists bool) *any {
+	fmt.Printf("setValInAny src pointer %p val %v k:%v v:%v\n", src, *src, key, value)
+	if obj, ok := (*src).(map[any]any); ok { // check if this is a map
+		if _, ok := obj[key]; !ok || !ignoreIfExists {
+			obj[key] = value
+		}
+		return src
+	} else if slice, ok := (*src).([]any); ok { // check if this is a slice
+		if idx, ok := key.(int); ok {
+			if idx >= len(slice) { // if the index is out of bounds we need to append
+				slice = append(slice, value) // FIXME
+			} else if !ignoreIfExists {
+				slice[idx] = value
+			}
+			sliceToAny := (any)(slice)
+			*src = sliceToAny
+
+			fmt.Printf("setValInAny src after %p val %v \n", src, *src)
+			return &sliceToAny
+		}
+	}
+	panic("unexpected type")
+}
+
+func getValInAny(src *any, key any) *any {
+	var child *any
+	if obj, ok := (*src).(map[any]any); ok { // check if this is a map
+		if val, ok := obj[key]; ok {
+			child = &val
+		}
+	} else if slice, ok := (*src).([]any); ok { // check if this is a slice
+		if idx, ok := key.(int); ok {
+			if idx < len(slice) {
+				val := slice[idx]
+				child = &val
+			}
+		}
+	}
+	fmt.Printf("getValInAny src %p child %p \n", src, child)
+	return child
+}
+
+func AddHeaders(source cose.ProtectedHeader, customHeaders map[string]string) cose.ProtectedHeader {
+	// convert to any to be able to manipulate it
+	sourceMap := (map[any]any)(source)
+	fmt.Printf("sourceMap %p \n", &sourceMap)
+	sourceAny := (any)(sourceMap)
+	fmt.Printf("sourceAny %p \n", &sourceAny)
+
+	for key, nestedValue := range customHeaders {
+		// get the pointer to be able to move it around
+		current := &sourceAny
+		fmt.Printf("current %p \n", current)
+		// convert string to rune slice to be able to properly iterate over each character
+		keyRunes := []rune(key)
+		// use two pointers to iterate over the key
+		// the gap between the pointers indicates the key
+		for from := 0; from < len(keyRunes); from++ {
+			for to := from; to < len(keyRunes) && to >= from; to++ {
+				if to == len(keyRunes)-1 {
+					// if we reached the end of the key
+					// we can set the end value
+
+					// we are either in a map or a slice
+					if string(keyRunes[to]) == "]" {
+						// extract the index
+						index, err := strconv.Atoi(string(keyRunes[from:to]))
+						if err != nil {
+							// TODO: test this
+							log.Printf("conflict: %v is not a slice index\n", string(keyRunes[from:to]))
+							break
+						}
+						current = setValInAny(current, index, nestedValue, false)
+					} else {
+						detectedKey := headerKeyFromString(string(keyRunes[from:]))
+						current = setValInAny(current, detectedKey, nestedValue, false)
+					}
+					from = to + 1
+				} else if string(keyRunes[to]) == "." {
+					// FIXME: check if in array
+
+					// if we reached a dot then the value is a map
+					// we use the key to create a map if one doesn't exist
+					// then we move the pointer to the value to the map and move the pointers
+					detectedKey := headerKeyFromString(string(keyRunes[from:to]))
+					current = setValInAny(current, detectedKey, map[any]any{}, true)
+					current = getValInAny(current, detectedKey)
+					from = to + 1 // skip the dot
+				} else if string(keyRunes[to]) == "[" {
+					if to == 0 {
+						panic("header key cannot start with a square bracket")
+					}
+					// FIXME: check if in array
+
+					// square bracket means we have a slice
+					detectedKey := headerKeyFromString(string(keyRunes[from:to]))
+					// set it if it does not exist
+					current = setValInAny(current, detectedKey, make([]any, 0), true)
+					current = getValInAny(current, detectedKey)
+					from = to + 1 // skip the bracket
+				}
+			}
+		}
+	}
+
+	fmt.Printf("sourceAny after %p \n", &sourceAny)
+	// convert back to the original type
+	if sourceMap, ok := sourceAny.(map[any]any); ok {
+		return (cose.ProtectedHeader)(sourceMap)
+	}
+	return source
+}
+
+func CreateSignature(payload []byte, customHeaders map[string]string, hostport string) ([]byte, error) {
 	signer, err := keys.GetCoseSignerDefault()
 	if err != nil {
 		return nil, err
 	}
 	// create message header
 	headers := cose.Headers{
-		Protected: DefaultHeaders(contentType, hostport),
+		Protected: AddHeaders(DefaultHeaders(hostport), customHeaders),
 	}
+
 	// sign and marshal message
 	return cose.Sign1(rand.Reader, signer, headers, payload, nil)
 }

--- a/internal/signer/sig_test.go
+++ b/internal/signer/sig_test.go
@@ -123,13 +123,12 @@ func Test_AddHeaders(t *testing.T) {
 			kOut:    "a",
 			vOut:    map[any]any{"b": map[any]any{"c": map[any]any{"d": "nested"}}},
 		},
-		// {
-		// 	initial: cose.ProtectedHeader{},
-		// 	kIn:     "a[0]b",
-		// 	vIn:     "nestedmixed",
-		// 	kOut:    "a",
-		// 	vOut:    &[]any{map[any]any{"b": "nestedmixed"}},
-		// },
+		{
+			initial:     cose.ProtectedHeader{},
+			kIn:         "a[0]b",
+			vIn:         "nestedmixed",
+			errContains: "failed to set object value nestedmixed under key 0]b",
+		},
 	}
 
 	for _, tt := range tests {
@@ -141,6 +140,7 @@ func Test_AddHeaders(t *testing.T) {
 				require.Contains(t, err.Error(), tt.errContains)
 				return
 			}
+			require.NoError(t, err)
 			require.Equal(t, tt.vOut, tt.initial[tt.kOut])
 		})
 	}

--- a/routes.go
+++ b/routes.go
@@ -194,7 +194,7 @@ func SigCreateHandler() http.HandlerFunc {
 		}
 
 		kv := map[string]string{}
-		// for backwards compatibility when using contenttype field in the form
+		// @Deprecated use for backwards compatibility when using contenttype field in the form
 		contentType := r.PostForm.Get("contenttype")
 		if strings.Trim(contentType, " ") != "" {
 			kv["3"] = contentType

--- a/web/signature.tmpl
+++ b/web/signature.tmpl
@@ -12,9 +12,7 @@
 
     <div class="tab-pane fade show active" id="sig-new-form" role="tabpanel" aria-labelledby="sig-new-form-tab">
         <form id="sign" class="my-4" name="sign" action="/signature/create" method="POST" enctype="multipart/form-data">
-            <div class="mb-3">
-                <p class="small">Default Cose protected headers: <code>{{ .defaultHeaders }}</code></p>
-            </div>
+            
             <div class="mb-3">
                 <label for="payloadFile" class="form-label">Payload file</label>
                 <input type="file" name="payloadfile" class="form-control" aria-describedby="payloadfileHelp"
@@ -44,35 +42,38 @@
                 <div id="payloadHelp" class="form-text">If you do not have the file to upload but just 
                     its text content then use this field.</div>
             </div>
+
             <div class="mb-3">
-                <label for="contenttype" class="form-label">Content type</label>
-                <input name="contenttype" class="form-control" aria-describedby="contenttypeHelp" id="contenttype"
-                    placeholder="text/plain"></input>
-                <div id="contenttypeHelp" class="form-text">Content type of the payload to add to the headers, defaults
-                    to "text/plain"</div>
-            </div>
 
-            <div class="input-group mb-3">
-                <span class="input-group-text">Header</span>
-                <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
-                <span class="input-group-text">Value</span>
-                <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
-            </div>
+                <div class="input-group input-group-sm mb-3">
+                    <span class="input-group-text">Header</span>
+                    <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
+                    <span class="input-group-text">Value</span>
+                    <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
+                </div>
 
-            <div class="input-group mb-3">
-                <span class="input-group-text">Header</span>
-                <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
-                <span class="input-group-text">Value</span>
-                <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
-            </div>
+                <div class="input-group input-group-sm mb-3">
+                    <span class="input-group-text">Header</span>
+                    <input name="headerkey" type="text" class="form-control" placeholder="33[0]" aria-label="33[0]">
+                    <span class="input-group-text">Value</span>
+                    <input name="headerval" type="text" class="form-control" placeholder="b64value" aria-label="b64value">
+                </div>
 
-            <div class="input-group mb-3">
-                <span class="input-group-text">Header</span>
-                <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
-                <span class="input-group-text">Value</span>
-                <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
-            </div>
+                <div class="input-group input-group-sm mb-3">
+                    <span class="input-group-text">Header</span>
+                    <input name="headerkey" type="text" class="form-control" placeholder="15.1" aria-label="15.1">
+                    <span class="input-group-text">Value</span>
+                    <input name="headerval" type="text" class="form-control" placeholder="CWT claim issuer" aria-label="CWT claim issuer">
+                </div>
 
+                <div id="customheaderHelp" class="form-text">Header keys are usually ints 
+                    (see <a href="https://www.iana.org/assignments/cose/cose.xhtml">IANA</a>).
+                    Use dot notation to create maps and brackets for arrays (with limitations).
+                    To add more use API instead. Default Cose protected headers: 
+                    <code>{{ .defaultHeaders }}</code>
+                </div>
+
+            </div>
 
             <button type="submit" class="btn btn-primary">Create and download signature</button>
         </form>
@@ -82,9 +83,32 @@
         <div class="card text-bg-light my-4">
             <div class="card-header">Create with cURL</div>
             <div class="card-body">
+
+                <p class="card-text">Payload as a file:</p>
+                <pre class="card-text">curl -L 'https://playground-cose-eastus-api.azurewebsites.net/signature/create' -X POST \
+                  --form payloadfile='@./my/payload/file.txt' \
+                  -o signature.cose</pre>
+                <p class="card-text">Payload as a hex value:</p>
+                <pre class="card-text">curl -L 'https://playground-cose-eastus-api.azurewebsites.net/signature/create' -X POST \
+                  --form payloadhex='d2845828a301260446666f6f...17219018758186469643a77' \
+                  -o signature.cose</pre>
+                <p class="card-text">Payload as plain text:</p>
                 <pre class="card-text">curl -L 'https://playground-cose-eastus-api.azurewebsites.net/signature/create' -X POST \
                   --form payload='{"foo":"bar"}' \
-                  --form contenttype='application/json' \
+                  --form headerkey='3' \
+                  --form headerval='application/json' \
+                  -o signature.cose</pre>
+                <p class="card-text">Adding multiple headers:</p>
+                <pre class="card-text">curl -L 'https://playground-cose-eastus-api.azurewebsites.net/signature/create' -X POST \
+                  --form payloadfile='@./my/payload/file' \
+                  --form headerkey='3' \
+                  --form headerval='some/type' \
+                  --form headerkey='15.1' \
+                  --form headerval='did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:California:O:My%20Organisation' \
+                  --form headerkey='33[0]' \
+                  --form headerval='base64Cert' \
+                  --form headerkey='33[1]' \
+                  --form headerval='anotherBase64Cert' \
                   -o signature.cose</pre>
             </div>
         </div>

--- a/web/signature.tmpl
+++ b/web/signature.tmpl
@@ -52,6 +52,28 @@
                     to "text/plain"</div>
             </div>
 
+            <div class="input-group mb-3">
+                <span class="input-group-text">Header</span>
+                <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
+                <span class="input-group-text">Value</span>
+                <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
+            </div>
+
+            <div class="input-group mb-3">
+                <span class="input-group-text">Header</span>
+                <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
+                <span class="input-group-text">Value</span>
+                <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
+            </div>
+
+            <div class="input-group mb-3">
+                <span class="input-group-text">Header</span>
+                <input name="headerkey" type="text" class="form-control" placeholder="3" aria-label="3">
+                <span class="input-group-text">Value</span>
+                <input name="headerval" type="text" class="form-control" placeholder="text/plain" aria-label="text/plain">
+            </div>
+
+
             <button type="submit" class="btn btn-primary">Create and download signature</button>
         </form>
     </div>


### PR DESCRIPTION
Allow overriding the existing and adding new headers to COSE. It would be necessary to support nesting to allow CWT_Claims and arrays for x509 chains.